### PR TITLE
fixed a hole in the github ip restriction

### DIFF
--- a/nginx.vhost
+++ b/nginx.vhost
@@ -4,8 +4,13 @@ server {
 	location / {
 		proxy_pass http://localhost:8010;
 	}
-	location /change_hook/github/ {
-		allow 207.97.227.253/32 50.57.128.197/32 108.171.174.178/32 50.57.231.61/32 204.232.175.64/27 192.30.252.0/22;
+	location /change_hook/github {
+		allow 207.97.227.253/32;
+		allow 50.57.128.197/32;
+		allow 108.171.174.178/32;
+		allow 50.57.231.61/32;
+		allow 204.232.175.64/27;
+		allow 192.30.252.0/22;
 		deny all;
 	}
 }


### PR DESCRIPTION
Simply accessing /change_hook/github (without a slash in the end) allowed you to bypass the IP limitation. Also, the IPs in one line did not work on nginx 1.6.0.
